### PR TITLE
fix: type error accessing channel_description is False (bool)

### DIFF
--- a/ta-helper.py
+++ b/ta-helper.py
@@ -181,6 +181,9 @@ while channels_json['paginate']['last_page']:
                      
 for channel in channels_data:
     chan_name = urlify(channel['channel_name'])
+    # some channels have False as channel_description, which later on gives a type error
+    if not channel['channel_description']:
+        channel['channel_description'] = ""
     description = channel['channel_description']
     logger.debug("Video Description: " + description)
     logger.debug("Channel Name: " + chan_name)


### PR DESCRIPTION
change channel_description to empty string if False

ta-helper could not import my tubearchivist lib because some channels had an boolean `False` as channel_description.
this fixed it.